### PR TITLE
Corrige método "str_real_to_float" para tratar casos no qual o valor é maior que 1000

### DIFF
--- a/lib/pombo/support.rb
+++ b/lib/pombo/support.rb
@@ -12,7 +12,7 @@ module Pombo
     #   # => '2.00'
     def self.str_real_to_float(value)
       raise TypeError, "no implicit conversion of #{ value.class.name } into String" unless value.kind_of? String
-      value.tr(',','.').to_f
+      value.tr('.','').tr(',','.').to_f
     end
 
     # Used to convert Boolean values to String

--- a/spec/pombo/support_spec.rb
+++ b/spec/pombo/support_spec.rb
@@ -15,6 +15,10 @@ describe Pombo::Support do
       expect(subject.str_real_to_float('2,99')).to eq(2.99)
     end
 
+    it 'converts real above thousand string to float' do
+      expect(subject.str_real_to_float('2.879,99')).to eq(2879.99)
+    end
+
     it 'throw exception if the value is not string' do
       expect { subject.str_real_to_float(2) }.to raise_error TypeError
     end


### PR DESCRIPTION
No método "str_real_to_float" do modulo de support havia um bug caso o valor fosse maior de 1000.

ex.:
- antigo: "1.061,80" => "1.061"
- atual: "1.061,80" => "1061.80"

